### PR TITLE
Don't commit patch conflicts

### DIFF
--- a/build-logic/src/main/kotlin/io/papermc/mache/constants/constants.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/constants/constants.kt
@@ -18,3 +18,4 @@ const val DECOMP_JAR = "$SERVER_DIR/decomp.jar"
 const val DECOMP_CFG = "$SERVER_DIR/decomp.cfg"
 
 const val PATCHED_JAR = "$SERVER_DIR/patched.jar"
+const val FAILED_PATCH_JAR = "$SERVER_DIR/failed_patch.jar"

--- a/build-logic/src/main/kotlin/io/papermc/mache/tasks/ApplyPatches.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/tasks/ApplyPatches.kt
@@ -121,13 +121,6 @@ abstract class ApplyPatches : DefaultTask() {
                                     copyEntry(input, failedZos, zipEntry)
                                 }
                             }
-                            val rejectName = zipEntry.name + ".rej"
-                            val rejectFile = tempOutDir.resolve(rejectName)
-                            if (rejectFile.exists()) {
-                                rejectFile.inputStream().buffered().use { input ->
-                                    copyEntry(input, failedZos, ZipEntry(rejectName))
-                                }
-                            }
                         }
                     }
                 }

--- a/build-logic/src/main/kotlin/io/papermc/mache/util/patches/JavaPatcher.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/util/patches/JavaPatcher.kt
@@ -17,7 +17,7 @@ import kotlin.io.path.writeLines
 
 internal open class JavaPatcher : Patcher {
 
-    override fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path): PatchResult {
+    override fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path, failedDir: Path): PatchResult {
         val result = baseDir.walk()
             .filter { it.name.endsWith(".java") }
             .map { original ->

--- a/build-logic/src/main/kotlin/io/papermc/mache/util/patches/NativePatcher.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/util/patches/NativePatcher.kt
@@ -3,17 +3,12 @@ package io.papermc.mache.util.patches
 import java.io.ByteArrayOutputStream
 import java.nio.charset.Charset
 import java.nio.file.Path
-import kotlin.io.path.absolutePathString
-import kotlin.io.path.copyTo
-import kotlin.io.path.createDirectories
-import kotlin.io.path.name
-import kotlin.io.path.relativeTo
-import kotlin.io.path.walk
 import org.gradle.process.ExecOperations
+import kotlin.io.path.*
 
 internal open class NativePatcher(private val exec: ExecOperations, protected val patchExecutable: String) : Patcher {
 
-    override fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path): PatchResult {
+    override fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path, failedDir: Path): PatchResult {
         baseDir.walk()
             .filter { it.name.endsWith(".java") }
             .forEach { original ->
@@ -25,7 +20,7 @@ internal open class NativePatcher(private val exec: ExecOperations, protected va
 
         val result = patchDir.walk()
             .fold<_, PatchResult>(PatchSuccess) { acc, value ->
-                acc.fold(patch(outputDir, value))
+                acc.fold(patch(outputDir, failedDir, patchDir, value))
             }
 
         return result
@@ -35,7 +30,7 @@ internal open class NativePatcher(private val exec: ExecOperations, protected va
         return listOf(patchExecutable, "-u", "-p1", "--merge=diff3", "-i", patch.absolutePathString())
     }
 
-    private fun patch(out: Path, patch: Path): PatchResult {
+    private fun patch(out: Path, failed: Path, patchDir: Path, patch: Path): PatchResult {
         val baos = ByteArrayOutputStream()
         val res = exec.exec {
             commandLine(commandLineArgs(patch))
@@ -48,6 +43,9 @@ internal open class NativePatcher(private val exec: ExecOperations, protected va
         }
         if (res.exitValue == 0) {
             return PatchSuccess
+        } else {
+            val file = patch.relativeTo(patchDir).parent.resolve(patch.fileName.toString().removeSuffix(".patch"))
+            out.resolve(file).moveTo(failed.resolve(file).apply { parent?.createDirectories() })
         }
 
         return PatchFailure(patch, baos.toString(Charset.defaultCharset()))

--- a/build-logic/src/main/kotlin/io/papermc/mache/util/patches/NativePatcher.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/util/patches/NativePatcher.kt
@@ -41,11 +41,16 @@ internal open class NativePatcher(private val exec: ExecOperations, protected va
 
             isIgnoreExitValue = true
         }
+
         if (res.exitValue == 0) {
             return PatchSuccess
         } else {
-            val file = patch.relativeTo(patchDir).parent.resolve(patch.fileName.toString().removeSuffix(".patch"))
-            out.resolve(file).moveTo(failed.resolve(file).apply { parent?.createDirectories() })
+            val inputFile = patch.resolveSibling(patch.nameWithoutExtension)
+            val inputFilePath = inputFile.relativeTo(patchDir).toString()
+
+            val failedOutput = failed.resolve(inputFilePath)
+            failedOutput.parent.createDirectories()
+            out.resolve(inputFilePath).moveTo(failedOutput)
         }
 
         return PatchFailure(patch, baos.toString(Charset.defaultCharset()))

--- a/build-logic/src/main/kotlin/io/papermc/mache/util/patches/Patcher.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/util/patches/Patcher.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 internal interface Patcher {
 
-    fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path): PatchResult
+    fun applyPatches(baseDir: Path, patchDir: Path, outputDir: Path, failedDir: Path): PatchResult
 }
 
 internal sealed interface PatchResult {


### PR DESCRIPTION
Not committing the patch conflicts makes it easier to see what patches/files conflicted with git and/or IDE tools that track changed files.

This is done by collecting failed patches in the apply patches tasks and passing them to the task that is set as the finalizer for both patch tasks.

If there is a better way to handle the SetupSource task, so that you don't have to create two of them, one for each apply task, let me know. I couldn't figure out a way to configure the task directly when setting the finalizer.