### PR TITLE
Ensure the "failed patches" zip always exists, even when the patches directory doesn't, or is empty.

### DIFF
--- a/build-logic/src/main/kotlin/io/papermc/mache/tasks/ApplyPatches.kt
+++ b/build-logic/src/main/kotlin/io/papermc/mache/tasks/ApplyPatches.kt
@@ -82,6 +82,7 @@ abstract class ApplyPatches : DefaultTask() {
 
         if (!patchesPresent) {
             inputFile.convertToPath().copyTo(out)
+            failed.writeZip { }
             return
         }
 


### PR DESCRIPTION
Fixes issue where the build fails, is the patch directory doesnt exist.
This is useful for testing / rebuilding all patches from scratch

fixes failed build if you wanted to start from no patches