### PR TITLE
Fix running server

### DIFF
--- a/versions/1.20.6/patches/net/minecraft/world/level/levelgen/BitRandomSource.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/world/level/levelgen/BitRandomSource.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/levelgen/BitRandomSource.java
++++ b/net/minecraft/world/level/levelgen/BitRandomSource.java
+@@ -18,7 +_,7 @@
+         if (bound <= 0) {
+             throw new IllegalArgumentException("Bound must be positive");
+         } else if ((bound & bound - 1) == 0) {
+-            return (int)(bound * this.next(31) >> 31);
++            return (int)((long) bound * (long) this.next(31) >> 31);
+         } else {
+             int i;
+             int i1;


### PR DESCRIPTION
`BitRandomSource.java.patch` fixes an exception while trying to use `runServer`

```
> Task :versions:v1_20_6:runServer
Exception in thread "main" java.lang.ExceptionInInitializerError
        at net.minecraft.world.level.biome.FixedBiomeSource.<clinit>(FixedBiomeSource.java:16)
        at net.minecraft.world.level.biome.BiomeSources.bootstrap(BiomeSources.java:8)
        at net.minecraft.core.registries.BuiltInRegistries.lambda$internalRegister$49(BuiltInRegistries.java:299)
        at net.minecraft.core.registries.BuiltInRegistries.lambda$createContents$50(BuiltInRegistries.java:312)
        at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:986)
        at net.minecraft.core.registries.BuiltInRegistries.createContents(BuiltInRegistries.java:311)
        at net.minecraft.core.registries.BuiltInRegistries.bootStrap(BuiltInRegistries.java:305)
        at net.minecraft.server.Bootstrap.bootStrap(Bootstrap.java:53)
        at net.minecraft.server.Main.main(Main.java:103)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 512
        at net.minecraft.world.level.levelgen.synth.SimplexNoise.<init>(SimplexNoise.java:46)
        at net.minecraft.world.level.levelgen.synth.PerlinSimplexNoise.<init>(PerlinSimplexNoise.java:29)
        at net.minecraft.world.level.levelgen.synth.PerlinSimplexNoise.<init>(PerlinSimplexNoise.java:16)
        at net.minecraft.world.level.biome.Biome.<clinit>(Biome.java:58)
        ... 9 more
```