### PR TITLE
Fix running server

### DIFF
--- a/versions/1.20.6/build.gradle.kts
+++ b/versions/1.20.6/build.gradle.kts
@@ -34,7 +34,7 @@ mache {
 dependencies {
     codebook("1.0.10")
     remapper(art("1.0.14"))
-    decompiler(vineflower("1.11.0-20240414.025732-15"))
+    decompiler(vineflower("1.11.0-20240523.155640-28"))
     parchment("1.20.5", "BLEEDING-SNAPSHOT")
 }
 

--- a/versions/1.20.6/patches/net/minecraft/advancements/critereon/PlayerPredicate.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/advancements/critereon/PlayerPredicate.java.patch
@@ -4,13 +4,13 @@
          private static <T> MapCodec<PlayerPredicate.StatMatcher<T>> createTypedCodec(StatType<T> statType) {
              return RecordCodecBuilder.mapCodec(
                  instance -> instance.group(
--                            (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, Holder<T>>)statType.getRegistry()
-+                            statType.getRegistry()
-                                 .holderByNameCodec()
-                                 .fieldOf("stat")
-                                 .forGetter(PlayerPredicate.StatMatcher::value),
--                            (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, MinMaxBounds.Ints>)MinMaxBounds.Ints.CODEC
-+                            MinMaxBounds.Ints.CODEC
-                                 .optionalFieldOf("value", MinMaxBounds.Ints.ANY)
-                                 .forGetter(PlayerPredicate.StatMatcher::range)
-                         )
+-                        (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, Holder<T>>)statType.getRegistry()
++                        statType.getRegistry()
+                             .holderByNameCodec()
+                             .fieldOf("stat")
+                             .forGetter(PlayerPredicate.StatMatcher::value),
+-                        (App<Mu<? extends PlayerPredicate.StatMatcher<?>>, MinMaxBounds.Ints>)MinMaxBounds.Ints.CODEC
++                        MinMaxBounds.Ints.CODEC
+                             .optionalFieldOf("value", MinMaxBounds.Ints.ANY)
+                             .forGetter(PlayerPredicate.StatMatcher::range)
+                     )

--- a/versions/1.20.6/patches/net/minecraft/commands/execution/tasks/BuildContexts.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/commands/execution/tasks/BuildContexts.java.patch
@@ -9,7 +9,7 @@
                          customModifierExecutor.apply(originalSource, list, contextChain, chainModifiers1, ExecutionControl.create(context, frame));
                          return;
                      }
-@@ -90,11 +_,11 @@
+@@ -91,11 +_,11 @@
  
          if (list.isEmpty()) {
              if (chainModifiers1.isReturn()) {

--- a/versions/1.20.6/patches/net/minecraft/commands/synchronization/SuggestionProviders.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/commands/synchronization/SuggestionProviders.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/commands/synchronization/SuggestionProviders.java
 +++ b/net/minecraft/commands/synchronization/SuggestionProviders.java
-@@ -48,7 +_,7 @@
+@@ -46,7 +_,7 @@
              throw new IllegalArgumentException("A command suggestion provider is already registered with the name " + name);
          } else {
              PROVIDERS_BY_NAME.put(name, provider);

--- a/versions/1.20.6/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -834,7 +_,7 @@
+@@ -833,7 +_,7 @@
      }
  
      @Override

--- a/versions/1.20.6/patches/net/minecraft/server/commands/ForceLoadCommand.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/server/commands/ForceLoadCommand.java.patch
@@ -3,9 +3,9 @@
 @@ -198,7 +_,7 @@
                          source.sendSuccess(
                              () -> Component.translatable(
-                                     "commands.forceload." + (add ? "added" : "removed") + ".multiple",
--                                    i2,
-+                                    i2x,
-                                     Component.translationArg(resourceKey.location()),
-                                     Component.translationArg(chunkPos2),
-                                     Component.translationArg(chunkPos3)
+                                 "commands.forceload." + (add ? "added" : "removed") + ".multiple",
+-                                i2,
++                                i2x,
+                                 Component.translationArg(resourceKey.location()),
+                                 Component.translationArg(chunkPos2),
+                                 Component.translationArg(chunkPos3)

--- a/versions/1.20.6/patches/net/minecraft/util/ExtraCodecs.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/ExtraCodecs.java.patch
@@ -1,11 +1,11 @@
 --- a/net/minecraft/util/ExtraCodecs.java
 +++ b/net/minecraft/util/ExtraCodecs.java
 @@ -218,7 +_,7 @@
-                 P object1 = list1.get(1);
-                 return factory.apply(object, object1);
-             }), object -> ImmutableList.of(minGetter.apply((I)object), maxGetter.apply((I)object)));
+             P object1 = list1.get(1);
+             return factory.apply(object, object1);
+         }), object -> ImmutableList.of(minGetter.apply((I)object), maxGetter.apply((I)object)));
 -        Codec<I> codec2 = RecordCodecBuilder.<Pair>create(
 +        Codec<I> codec2 = RecordCodecBuilder.<Pair<P, P>>create(
                  instance -> instance.group(codec.fieldOf(minFieldName).forGetter(Pair::getFirst), codec.fieldOf(maxFieldName).forGetter(Pair::getSecond))
-                         .apply(instance, Pair::of)
+                     .apply(instance, Pair::of)
              )

--- a/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/ChunkHeightAndBiomeFix.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/ChunkHeightAndBiomeFix.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/util/datafix/fixes/ChunkHeightAndBiomeFix.java
 +++ b/net/minecraft/util/datafix/fixes/ChunkHeightAndBiomeFix.java
-@@ -222,7 +_,8 @@
+@@ -220,7 +_,8 @@
          } else if (ints != null && ints.length == 1024) {
              for (int i1 = 0; i1 < 16; i1++) {
                  int i2 = i1 - i;

--- a/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java
 +++ b/net/minecraft/util/datafix/fixes/ChunkProtoTickListFix.java
-@@ -186,7 +_,7 @@
+@@ -181,7 +_,7 @@
          int i3 = i >>> 8 & 15;
          String string = function.apply(supplier != null ? supplier.get().get(i1, i2, i3) : null);
          return dynamic.createMap(

--- a/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/LeavesFix.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/LeavesFix.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/util/datafix/fixes/LeavesFix.java
 +++ b/net/minecraft/util/datafix/fixes/LeavesFix.java
-@@ -356,7 +_,7 @@
+@@ -353,7 +_,7 @@
                  : typed.update(DSL.remainderFinder(), dynamic -> dynamic.set("BlockStates", dynamic.createLongList(Arrays.stream(this.storage.getRaw()))))
                      .set(
                          this.paletteFinder,

--- a/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/OptionsKeyLwjgl3Fix.java.patch
@@ -9,11 +9,11 @@
  import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
  import java.util.stream.Collectors;
 @@ -160,7 +_,7 @@
-                             } else {
-                                 return Pair.of(entry.getKey(), entry.getValue());
-                             }
--                        }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(dynamic))
-+                        }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((Dynamic) dynamic))
+                 } else {
+                     return Pair.of(entry.getKey(), entry.getValue());
+                 }
+-            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(dynamic))
++            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((Dynamic) dynamic))
          );
      }
  }

--- a/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/util/datafix/fixes/OptionsKeyTranslationFix.java.patch
@@ -9,11 +9,11 @@
  
  public class OptionsKeyTranslationFix extends DataFix {
 @@ -26,7 +_,7 @@
-                             }
+                 }
  
-                             return Pair.of(entry.getKey(), entry.getValue());
--                        }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(dynamic))
-+                        }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((Dynamic) dynamic))
+                 return Pair.of(entry.getKey(), entry.getValue());
+-            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse(dynamic))
++            }).collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)))).result().orElse((Dynamic) dynamic))
          );
      }
  }

--- a/versions/1.20.6/patches/net/minecraft/world/entity/ai/behavior/InteractWith.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/world/entity/ai/behavior/InteractWith.java.patch
@@ -1,11 +1,11 @@
 --- a/net/minecraft/world/entity/ai/behavior/InteractWith.java
 +++ b/net/minecraft/world/entity/ai/behavior/InteractWith.java
 @@ -43,7 +_,7 @@
-                                         testEntity -> testEntity.distanceToSqr(entity) <= i && predicate.test(testEntity)
-                                     );
-                                     optional.ifPresent(target -> {
--                                        interact.set(target);
-+                                        interact.set((T) target);
-                                         lookTarget.set(new EntityTracker(target, true));
-                                         walkTarget.set(new WalkTarget(new EntityTracker(target, false), speedModifier, maxDist));
-                                     });
+                                 testEntity -> testEntity.distanceToSqr(entity) <= i && predicate.test(testEntity)
+                             );
+                             optional.ifPresent(target -> {
+-                                interact.set(target);
++                                interact.set((T) target);
+                                 lookTarget.set(new EntityTracker(target, true));
+                                 walkTarget.set(new WalkTarget(new EntityTracker(target, false), speedModifier, maxDist));
+                             });

--- a/versions/1.20.6/patches/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java.patch
+++ b/versions/1.20.6/patches/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java.patch
@@ -1,19 +1,19 @@
 --- a/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java
 +++ b/net/minecraft/world/entity/monster/piglin/StartHuntingHoglin.java
 @@ -19,14 +_,14 @@
-                         instance,
-                         (nearestVisibleHuntableHoglin, angryAt, huntedRecently, nearestVisibleAdultPiglins) -> (level, piglin, gameTime) -> {
-                                 if (!piglin.isBaby()
--                                    && !instance.<List>tryGet(nearestVisibleAdultPiglins)
-+                                    && !instance.tryGet(nearestVisibleAdultPiglins)
-                                         .map(adultPiglin -> adultPiglin.stream().anyMatch(StartHuntingHoglin::hasHuntedRecently))
-                                         .isPresent()) {
-                                     Hoglin hoglin = instance.get(nearestVisibleHuntableHoglin);
-                                     PiglinAi.setAngerTarget(piglin, hoglin);
-                                     PiglinAi.dontKillAnyMoreHoglinsForAWhile(piglin);
-                                     PiglinAi.broadcastAngerTarget(piglin, hoglin);
--                                    instance.<List>tryGet(nearestVisibleAdultPiglins)
-+                                    instance.tryGet(nearestVisibleAdultPiglins)
-                                         .ifPresent(adultPiglin -> adultPiglin.forEach(PiglinAi::dontKillAnyMoreHoglinsForAWhile));
-                                     return true;
-                                 } else {
+                     instance,
+                     (nearestVisibleHuntableHoglin, angryAt, huntedRecently, nearestVisibleAdultPiglins) -> (level, piglin, gameTime) -> {
+                         if (!piglin.isBaby()
+-                            && !instance.<List>tryGet(nearestVisibleAdultPiglins)
++                            && !instance.tryGet(nearestVisibleAdultPiglins)
+                                 .map(adultPiglin -> adultPiglin.stream().anyMatch(StartHuntingHoglin::hasHuntedRecently))
+                                 .isPresent()) {
+                             Hoglin hoglin = instance.get(nearestVisibleHuntableHoglin);
+                             PiglinAi.setAngerTarget(piglin, hoglin);
+                             PiglinAi.dontKillAnyMoreHoglinsForAWhile(piglin);
+                             PiglinAi.broadcastAngerTarget(piglin, hoglin);
+-                            instance.<List>tryGet(nearestVisibleAdultPiglins)
++                            instance.tryGet(nearestVisibleAdultPiglins)
+                                 .ifPresent(adultPiglin -> adultPiglin.forEach(PiglinAi::dontKillAnyMoreHoglinsForAWhile));
+                             return true;
+                         } else {


### PR DESCRIPTION
https://github.com/PaperMC/mache/pull/41#issuecomment-2149772124

Fixes:
```
> Task :versions:v1_20_6:runServer
Exception in thread "main" java.lang.ExceptionInInitializerError
        at net.minecraft.world.level.biome.FixedBiomeSource.<clinit>(FixedBiomeSource.java:16)
        at net.minecraft.world.level.biome.BiomeSources.bootstrap(BiomeSources.java:8)
        at net.minecraft.core.registries.BuiltInRegistries.lambda$internalRegister$49(BuiltInRegistries.java:299)
        at net.minecraft.core.registries.BuiltInRegistries.lambda$createContents$50(BuiltInRegistries.java:312)
        at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:986)
        at net.minecraft.core.registries.BuiltInRegistries.createContents(BuiltInRegistries.java:311)
        at net.minecraft.core.registries.BuiltInRegistries.bootStrap(BuiltInRegistries.java:305)
        at net.minecraft.server.Bootstrap.bootStrap(Bootstrap.java:53)
        at net.minecraft.server.Main.main(Main.java:103)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 512
        at net.minecraft.world.level.levelgen.synth.SimplexNoise.<init>(SimplexNoise.java:46)
        at net.minecraft.world.level.levelgen.synth.PerlinSimplexNoise.<init>(PerlinSimplexNoise.java:29)
        at net.minecraft.world.level.levelgen.synth.PerlinSimplexNoise.<init>(PerlinSimplexNoise.java:16)
        at net.minecraft.world.level.biome.Biome.<clinit>(Biome.java:58)
        ... 9 more
```