### PR TITLE
[ci skip] Update run directory names in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ bin/
 
 # Never includes the src or run directories
 versions/**/src
-versions/**/run
+versions/**/runServer
+versions/**/runClient
 # Ignore all versions by default
 versions/*
 # Don't ignore the current version


### PR DESCRIPTION
Due to the recent addition of the runClient functionality the run directory name has changed. The gitignore file still had the old name defined. 